### PR TITLE
Add the ability to allow contacts to have events (Contact calendar)

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddContactEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddContactEventCommand.java
@@ -1,0 +1,124 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT_DESCRIPTION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT_END_DATE_TIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT_START_DATE_TIME;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+
+import java.util.List;
+import java.util.Set;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.calendar.Calendar;
+import seedu.address.model.event.Event;
+import seedu.address.model.person.Address;
+import seedu.address.model.person.Email;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Phone;
+import seedu.address.model.tag.Tag;
+
+/**
+ * Adds an event to the calendar of an existing person in the address book.
+ */
+public class AddContactEventCommand extends Command {
+
+    public static final String COMMAND_WORD = "addContactEvent";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds an event to the calendar of the person "
+            + "identified by the index number used in the displayed person list.\n"
+            + "Parameters: "
+            + PREFIX_EVENT_DESCRIPTION + "DESCRIPTION "
+            + PREFIX_EVENT_START_DATE_TIME + "START DATE AND TIME "
+            + PREFIX_EVENT_END_DATE_TIME + "END DATE AND TIME...\n"
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_EVENT_DESCRIPTION + "Nap "
+            + PREFIX_EVENT_START_DATE_TIME + "2024-01-01 12:00 "
+            + PREFIX_EVENT_END_DATE_TIME + "2024-01-01 18:00";
+
+    public static final String MESSAGE_ADD_EVENT_TO_PERSON_SUCCESS = "New event added to %s: %2$s";
+    public static final String MESSAGE_EVENT_CONFLICT = "This event is conflicting with another event";
+
+    private final Index index;
+    private final Event event;
+
+    /**
+     * @param index of the person in the filtered person list to add an event to
+     * @param event event to be added to the person
+     */
+    public AddContactEventCommand(Index index, Event event) {
+        requireNonNull(index);
+        requireNonNull(event);
+
+        this.index = index;
+        this.event = event;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Person> lastShownList = model.getFilteredPersonList();
+
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        //Obtain the calendar of the person and tries to add an event to the person's calendar
+        Person personToEdit = lastShownList.get(index.getZeroBased());
+        Calendar calendar = personToEdit.getCalendar();
+        if (!calendar.canAddEvent(event)) {
+            throw new CommandException(MESSAGE_EVENT_CONFLICT);
+        }
+        calendar.addEvent(event);
+        Person editedPerson = createEditedPerson(personToEdit, calendar);
+        model.setPerson(personToEdit, editedPerson);
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        return new CommandResult(String.format(MESSAGE_ADD_EVENT_TO_PERSON_SUCCESS,
+                editedPerson.getName(), Messages.format(event)));
+    }
+
+    /**
+     * Creates and returns a {@code Person} with the new Calendar {@code calendar}
+     * edited with {@code event}.
+     */
+    private static Person createEditedPerson(Person personToEdit, Calendar calendar) {
+        assert personToEdit != null;
+
+        Name updatedName = personToEdit.getName();
+        Phone updatedPhone = personToEdit.getPhone();
+        Email updatedEmail = personToEdit.getEmail();
+        Address updatedAddress = personToEdit.getAddress();
+        Set<Tag> updatedTags = personToEdit.getTags();
+
+        return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags, calendar);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof AddContactEventCommand)) {
+            return false;
+        }
+
+        AddContactEventCommand otherAddContactEventCommand = (AddContactEventCommand) other;
+        return index.equals(otherAddContactEventCommand.index)
+                && event.equals(otherAddContactEventCommand.event);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("index", index)
+                .add("event", event)
+                .toString();
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -21,6 +21,7 @@ import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.calendar.Calendar;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
@@ -100,8 +101,9 @@ public class EditCommand extends Command {
         Email updatedEmail = editPersonDescriptor.getEmail().orElse(personToEdit.getEmail());
         Address updatedAddress = editPersonDescriptor.getAddress().orElse(personToEdit.getAddress());
         Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
+        Calendar calendar = personToEdit.getCalendar();
 
-        return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags);
+        return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags, calendar);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/parser/AddContactEventCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddContactEventCommandParser.java
@@ -1,0 +1,66 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT_DESCRIPTION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT_END_DATE_TIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT_START_DATE_TIME;
+
+import java.util.stream.Stream;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.AddContactEventCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.event.Event;
+import seedu.address.model.event.EventDescription;
+import seedu.address.model.event.EventPeriod;
+
+/**
+ * Parses input arguments and creates a new AddContactEventCommand object
+ */
+public class AddContactEventCommandParser implements Parser<AddContactEventCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the AddContactEventCommand
+     * and returns an AddContactEventCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public AddContactEventCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_EVENT_DESCRIPTION, PREFIX_EVENT_START_DATE_TIME,
+                        PREFIX_EVENT_END_DATE_TIME);
+
+        Index index;
+        try {
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    AddContactEventCommand.MESSAGE_USAGE), pe);
+        }
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_EVENT_DESCRIPTION, PREFIX_EVENT_START_DATE_TIME,
+                PREFIX_EVENT_END_DATE_TIME)) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    AddContactEventCommand.MESSAGE_USAGE));
+        }
+
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_EVENT_DESCRIPTION, PREFIX_EVENT_START_DATE_TIME,
+                PREFIX_EVENT_END_DATE_TIME);
+        EventDescription description = ParserUtil.parseEventDescription(argMultimap
+                .getValue(PREFIX_EVENT_DESCRIPTION).get());
+        EventPeriod eventPeriod = ParserUtil.parseEventPeriod(argMultimap.getValue(PREFIX_EVENT_START_DATE_TIME).get(),
+                argMultimap.getValue(PREFIX_EVENT_END_DATE_TIME).get());
+
+        return new AddContactEventCommand(index, new Event(description, eventPeriod));
+    }
+
+    /**
+     * Checks if all the given prefix fields are non-empty.
+     *
+     * @param argumentMultimap argumentMultimap managing arguments for this command.
+     * @param prefixes prefixes to be tested.
+     * @return true if all fields are non-empty, false if any field contains empty value.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/UniMateParser.java
+++ b/src/main/java/seedu/address/logic/parser/UniMateParser.java
@@ -95,11 +95,11 @@ public class UniMateParser {
         case DeleteEventCommand.COMMAND_WORD:
             return new DeleteEventCommandParser().parse(arguments);
 
-        case AddContactEventCommand.COMMAND_WORD:
-            return new AddContactEventCommandParser().parse(arguments);
-            
         case ClearEventsCommand.COMMAND_WORD:
             return new ClearEventsCommandParser().parse(arguments);
+
+        case AddContactEventCommand.COMMAND_WORD:
+            return new AddContactEventCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/UniMateParser.java
+++ b/src/main/java/seedu/address/logic/parser/UniMateParser.java
@@ -9,6 +9,7 @@ import java.util.regex.Pattern;
 
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.AddContactEventCommand;
 import seedu.address.logic.commands.AddEventCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
@@ -92,6 +93,9 @@ public class UniMateParser {
 
         case DeleteEventCommand.COMMAND_WORD:
             return new DeleteEventCommandParser().parse(arguments);
+
+        case AddContactEventCommand.COMMAND_WORD:
+            return new AddContactEventCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -55,6 +55,7 @@ public class Person {
         this.calendar.resetData(calendar);
     }
 
+
     public Name getName() {
         return name;
     }

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -8,6 +8,7 @@ import java.util.Objects;
 import java.util.Set;
 
 import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.model.calendar.Calendar;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -24,8 +25,10 @@ public class Person {
     // Data fields
     private final Address address;
     private final Set<Tag> tags = new HashSet<>();
+    private final Calendar calendar = new Calendar();
 
     /**
+     * Primary constructor for a person object.
      * Every field must be present and not null.
      */
     public Person(Name name, Phone phone, Email email, Address address, Set<Tag> tags) {
@@ -35,6 +38,21 @@ public class Person {
         this.email = email;
         this.address = address;
         this.tags.addAll(tags);
+    }
+
+    /**
+     * Alternative constructor to be used when replacing the calendar of a contact.
+     * Every field must be present and not null.
+     *
+     */
+    public Person(Name name, Phone phone, Email email, Address address, Set<Tag> tags, Calendar calendar) {
+        requireAllNonNull(name, phone, email, address, tags);
+        this.name = name;
+        this.phone = phone;
+        this.email = email;
+        this.address = address;
+        this.tags.addAll(tags);
+        this.calendar.resetData(calendar);
     }
 
     public Name getName() {
@@ -51,6 +69,10 @@ public class Person {
 
     public Address getAddress() {
         return address;
+    }
+
+    public Calendar getCalendar() {
+        return calendar;
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/AddContactEventCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddContactEventCommandTest.java
@@ -1,0 +1,100 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.testutil.TypicalEvents.LAUNCH;
+import static seedu.address.testutil.TypicalEvents.TRAINING;
+import static seedu.address.testutil.TypicalEvents.getTypicalCalendar;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.event.Event;
+import seedu.address.model.person.Person;
+
+public class AddContactEventCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), getTypicalCalendar(), new UserPrefs());
+
+    @Test
+    public void execute_addEvent_success() {
+        Person person = ALICE;
+        Event event = TRAINING;
+        AddContactEventCommand addContactEventCommand = new AddContactEventCommand(INDEX_FIRST_PERSON, event);
+
+        String expectedMessage = String.format(AddContactEventCommand.MESSAGE_ADD_EVENT_TO_PERSON_SUCCESS,
+                person.getName(), Messages.format(event));
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()),
+                model.getCalendar(), new UserPrefs());
+        expectedModel.setPerson(model.getFilteredPersonList().get(0), person);
+
+        assertCommandSuccess(addContactEventCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidPersonIndexUnfilteredList_failure() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        AddContactEventCommand addContactEventCommand = new AddContactEventCommand(outOfBoundIndex, TRAINING);
+
+        assertCommandFailure(addContactEventCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    /**
+     * Add event to filtered list where index is larger than size of filtered list,
+     * but smaller than size of address book
+     */
+    @Test
+    public void execute_invalidPersonIndexFilteredList_failure() {
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+        Index outOfBoundIndex = INDEX_SECOND_PERSON;
+        // ensures that outOfBoundIndex is still in bounds of address book list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
+
+        AddContactEventCommand addContactEventCommand = new AddContactEventCommand(outOfBoundIndex, TRAINING);
+
+        assertCommandFailure(addContactEventCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        final AddContactEventCommand standardCommand = new AddContactEventCommand(INDEX_FIRST_PERSON, TRAINING);
+
+        // same object -> returns true
+        assertTrue(standardCommand.equals(standardCommand));
+
+        // null -> returns false
+        assertFalse(standardCommand.equals(null));
+
+        // different types -> returns false
+        assertFalse(standardCommand.equals(new ClearCommand()));
+
+        // different index -> returns false
+        assertFalse(standardCommand.equals(new AddContactEventCommand(INDEX_SECOND_PERSON, TRAINING)));
+
+        // different event -> returns false
+        assertFalse(standardCommand.equals(new AddContactEventCommand(INDEX_FIRST_PERSON, LAUNCH)));
+    }
+
+    @Test
+    public void toStringMethod() {
+        Index index = Index.fromOneBased(1);
+        Event event = TRAINING;
+        AddContactEventCommand addContactEventCommand = new AddContactEventCommand(index, event);
+        String expected = AddContactEventCommand.class.getCanonicalName() + "{index=" + index + ", event="
+                + event + "}";
+        assertEquals(expected, addContactEventCommand.toString());
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -4,6 +4,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT_DESCRIPTION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT_END_DATE_TIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT_START_DATE_TIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
@@ -46,6 +49,9 @@ public class CommandTestUtil {
     public static final String VALID_END_DATE_EARLIER = "2023-01-01 09:00";
     public static final String VALID_START_DATE_LATER = "2024-01-01 08:00";
     public static final String VALID_END_DATE_LATER = "2024-01-01 09:00";
+    public static final String EVENT_DESC_SLEEP = " " + PREFIX_EVENT_DESCRIPTION + VALID_DESCRIPTION;
+    public static final String START_DATE_DESC_EARLIER = " " + PREFIX_EVENT_START_DATE_TIME + VALID_START_DATE_EARLIER;
+    public static final String END_DATE_DESC_EARLIER = " " + PREFIX_EVENT_END_DATE_TIME + VALID_END_DATE_EARLIER;
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;
     public static final String PHONE_DESC_AMY = " " + PREFIX_PHONE + VALID_PHONE_AMY;
@@ -64,6 +70,9 @@ public class CommandTestUtil {
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags
     public static final String INVALID_DESCRIPTION = ""; // empty string not allowed.
     public static final String INVALID_DATE = "2023-13-35 16:80"; // No such time and date exists
+    public static final String INVALID_EVENT = " " + PREFIX_EVENT_DESCRIPTION + INVALID_DESCRIPTION
+            + PREFIX_EVENT_START_DATE_TIME + VALID_START_DATE_EARLIER
+            + PREFIX_EVENT_END_DATE_TIME + VALID_END_DATE_EARLIER;
 
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";

--- a/src/test/java/seedu/address/logic/parser/AddContactEventCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddContactEventCommandParserTest.java
@@ -1,0 +1,75 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.END_DATE_DESC_EARLIER;
+import static seedu.address.logic.commands.CommandTestUtil.EVENT_DESC_SLEEP;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_EVENT;
+import static seedu.address.logic.commands.CommandTestUtil.START_DATE_DESC_EARLIER;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_DESCRIPTION;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_END_DATE_EARLIER;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_START_DATE_EARLIER;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.AddContactEventCommand;
+import seedu.address.model.event.Event;
+import seedu.address.testutil.EventBuilder;
+
+public class AddContactEventCommandParserTest {
+
+    private static final String MESSAGE_INVALID_FORMAT =
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddContactEventCommand.MESSAGE_USAGE);
+    private static final String VALID_EVENT = EVENT_DESC_SLEEP + START_DATE_DESC_EARLIER + END_DATE_DESC_EARLIER;
+
+    private AddContactEventCommandParser parser = new AddContactEventCommandParser();
+
+    @Test
+    public void parse_missingParts_failure() {
+        // no index specified
+        assertParseFailure(parser, VALID_EVENT, MESSAGE_INVALID_FORMAT);
+
+        // no field specified
+        assertParseFailure(parser, "1", MESSAGE_INVALID_FORMAT);
+
+        // no index and no field specified
+        assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_invalidPreamble_failure() {
+        // negative index
+        assertParseFailure(parser, "-5" + VALID_EVENT, MESSAGE_INVALID_FORMAT);
+
+        // zero index
+        assertParseFailure(parser, "0" + VALID_EVENT, MESSAGE_INVALID_FORMAT);
+
+        // invalid arguments being parsed as preamble
+        assertParseFailure(parser, "1 some random string", MESSAGE_INVALID_FORMAT);
+
+        // invalid prefix being parsed as preamble
+        assertParseFailure(parser, "1 i/ string", MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_invalidValue_failure() {
+        assertParseFailure(parser, "1" + INVALID_EVENT, MESSAGE_INVALID_FORMAT); // invalid event
+    }
+
+    @Test
+    public void parse_validEvent_success() {
+        Index targetIndex = INDEX_SECOND_PERSON;
+        String userInput = targetIndex.getOneBased() + VALID_EVENT;
+
+        Event event = new EventBuilder()
+                .withDescription(VALID_DESCRIPTION)
+                .withStartEndDate(VALID_START_DATE_EARLIER, VALID_END_DATE_EARLIER)
+                .build();
+        AddContactEventCommand expectedCommand = new AddContactEventCommand(targetIndex, event);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/UniMateParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UniMateParserTest.java
@@ -14,6 +14,7 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.AddContactEventCommand;
 import seedu.address.logic.commands.AddEventCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.DeleteCommand;
@@ -118,6 +119,24 @@ public class UniMateParserTest {
                 + SortCommand.SORTBY_KEYWORD3 + " " + SortCommand.REVERSE_KEYWORD) instanceof SortCommand);
         assertTrue(parser.parseCommand(SortCommand.COMMAND_WORD + " "
                 + SortCommand.SORTBY_KEYWORD4 + " " + SortCommand.REVERSE_KEYWORD) instanceof SortCommand);
+    }
+
+    @Test
+    public void parserCommand_addContactEvent() throws Exception {
+        String description = "sleep";
+        String startDateTime = "2023-10-10 10:00";
+        String endDateTime = "2023-10-10 12:00";
+        String validArg = "d/" + description
+                + " ts/" + startDateTime
+                + " te/" + endDateTime;
+        EventBuilder eventBuilder = new EventBuilder();
+        eventBuilder.withDescription(description);
+        eventBuilder.withStartEndDate(startDateTime, endDateTime);
+        AddContactEventCommand command =
+                (AddContactEventCommand) parser.parseCommand(AddContactEventCommand.COMMAND_WORD + " "
+                + INDEX_FIRST_PERSON.getOneBased() + " " + validArg);
+
+        assertEquals(command, new AddContactEventCommand(INDEX_FIRST_PERSON, eventBuilder.build()));
     }
 
     @Test


### PR DESCRIPTION
This allows the addition of events to address book contacts.

Addition of events to contacts can be strictly only done by the AddContactEventCommand.
Creating a new Person will have an empty calendar initialized by default.
Editing an existing person will reuse the existing calendar possessed by him.