### PR TITLE
Bug Fixing 1

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -130,13 +130,13 @@ Examples:
 * `find alex david` returns `Alex Yeoh`, `David Li`<br>
   ![result for 'find alex david'](images/findAlexDavidResult.png)
 
-### Locating persons by tag: `filter`
+### Locating persons by field: `filter`
 
 Finds persons whose fields contain any of the given keywords.
 
 Format: `filter [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [t/TAG]…​`
 
-* Filter is case-insensitive. e.g. `cs2103` will match `CS2103`
+* Filter is non case-insensitive. e.g. `cs2103` will match `CS2103`
 * The order of the fields does not matter.
 * All provided fields are searched
 * All tags containing the words will be matched e.g. `Ba` will return `Badminton` or `Basketball` or `Football` or `Backgammon`.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -382,7 +382,7 @@ Format: `viewContactEvents INDEX`
 
 ## Task Management System
 
-Tasks consist of a `DESCRIPTION` and a `DEADLINE`. 
+Tasks consist of a `DESCRIPTION` and a `DEADLINE`.
 
 ### Viewing tasks: `switchList`
 
@@ -404,6 +404,8 @@ Format: `addTask d/DESCRIPTION [te/DEADLINE]`
 * `DEADLINE` can also be omitted to create a task with no specified deadline.
 * When adding a task with a deadline with a date that is invalid but with a day of 31 or less, instead adds a task with 
 a deadline on the last day of the month.
+* While there is no character limit for Task descriptions, descriptions will be truncated if they are too long to 
+display.
 
 Examples: 
 * `addTask d/Go for a run te/2023-02-14 19:00`

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -400,11 +400,14 @@ Format: `addTask d/DESCRIPTION [te/DEADLINE]`
 
 * `DESCRIPTION` cannot be empty.
 * `DEADLINE` must be in the same format given above for date and time.
-* `DEADLINE` can also be omitted to create a task with no specified deadline
+* `DEADLINE` can also be omitted to create a task with no specified deadline.
+* When adding a task with a deadline with a date that is invalid but with a day of 31 or less, instead adds a task with 
+a deadline on the last day of the month.
 
 Examples: 
 * `addTask d/Go for a run te/2023-02-14 19:00`
 * `addTask d/Hydrate regularly!`
+* `addTask d/Fix CS2103 Project bug te/2023-02-31 12:00` creates the task with deadline `2023-02-28 12:00` instead.
 
 ### Deleting tasks: `deleteTask`
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -332,7 +332,7 @@ Example:
 
 Clears all events within a specified time range.
 
-Format: `clearEvents ts/START_DATE_TIME te/END_DATE_TIME c/CONFIRMATION`
+Format: `clearEvents ts/START_DATE_TIME te/END_DATE_TIME [c/CONFIRMATION]`
 
 * Deletes all events from the specified start date and time to the specified end date and time.
 * An event is considered to be within the time range if overlaps with the time range for any period of time.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -141,6 +141,7 @@ Format: `filter [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [t/TAG]…​`
 * All provided fields are searched
 * All tags containing the words will be matched e.g. `Ba` will return `Badminton` or `Basketball` or `Football` or `Backgammon`.
 * Only persons matching all specified fields will be returned (i.e. `and` search).
+* Indicating a field but leaving it blank e.g. `filter n/` will show all contacts.
 
 Examples:
 * `filter t/CS2103` - Displays all contacts with the CS2103 tag or tags containing ``CS2103`` e.g. CS2103T

--- a/src/main/java/seedu/address/logic/commands/ClearEventsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearEventsCommand.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CONFIRMATION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT_END_DATE_TIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT_START_DATE_TIME;
 
@@ -21,9 +22,11 @@ import seedu.address.model.event.EventPeriod;
 public class ClearEventsCommand extends Command {
     public static final String COMMAND_WORD = "clearEvents";
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Deletes events within a time range from the calendar. "
+            + "Shows all events within the time range instead if confirmation is not present.\n"
             + "Parameters: "
             + PREFIX_EVENT_START_DATE_TIME + "START DATE AND TIME "
-            + PREFIX_EVENT_END_DATE_TIME + "END DATE AND TIME\n"
+            + PREFIX_EVENT_END_DATE_TIME + "END DATE AND TIME ["
+            + PREFIX_CONFIRMATION + "CONFIRMATION]\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_EVENT_START_DATE_TIME + "2024-01-01 12:00 "
             + PREFIX_EVENT_END_DATE_TIME + "2024-01-01 18:00";

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -5,6 +5,7 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -18,6 +19,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.logic.parser.exceptions.RuntimeParseException;
 import seedu.address.model.event.EventDescription;
 import seedu.address.model.event.EventPeriod;
+import seedu.address.model.event.exceptions.InvalidEventPeriodException;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
@@ -218,8 +220,12 @@ public class ParserUtil {
         requireAllNonNull(startDate, endDate);
         String trimmedStartDate = startDate.trim();
         String trimmedEndDate = endDate.trim();
-        if (!EventPeriod.isValidPeriod(trimmedStartDate, trimmedEndDate)) {
+        try {
+            EventPeriod.isValidPeriod(trimmedStartDate, trimmedEndDate);
+        } catch (DateTimeParseException dateTimeParseException) {
             throw new ParseException(EventPeriod.MESSAGE_CONSTRAINTS);
+        } catch (InvalidEventPeriodException invalidEventPeriodException) {
+            throw new ParseException(EventPeriod.PERIOD_INVALID);
         }
         return new EventPeriod(trimmedStartDate, trimmedEndDate);
     }

--- a/src/main/java/seedu/address/model/event/EventPeriod.java
+++ b/src/main/java/seedu/address/model/event/EventPeriod.java
@@ -10,7 +10,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;

--- a/src/main/java/seedu/address/model/event/EventPeriod.java
+++ b/src/main/java/seedu/address/model/event/EventPeriod.java
@@ -30,7 +30,7 @@ public class EventPeriod implements Comparable<EventPeriod> {
     public static final String PERIOD_INVALID = "The start date has to be before the end date.";
     public static final DateTimeFormatter DATE_TIME_STRING_FORMATTER = DateTimeFormatter.ofPattern(
             "yyyy-MM-dd HH:mm");
-    private static final LocalTime MAX_TIME_OF_DAY = LocalTime.MIDNIGHT.minusMinutes(1);
+    public static final LocalTime MAX_TIME_OF_DAY = LocalTime.MIDNIGHT.minusMinutes(1);
 
     private final LocalDateTime start;
     private final LocalDateTime end;

--- a/src/main/java/seedu/address/model/event/EventPeriod.java
+++ b/src/main/java/seedu/address/model/event/EventPeriod.java
@@ -91,7 +91,7 @@ public class EventPeriod implements Comparable<EventPeriod> {
         endDateTime = LocalDateTime.parse(endString, DATE_TIME_STRING_FORMATTER);
 
         if (!startDateTime.isBefore(endDateTime)) {
-            throw new InvalidEventPeriodException();
+            throw new InvalidEventPeriodException(PERIOD_INVALID);
         }
         return true;
     }

--- a/src/main/java/seedu/address/model/event/EventPeriod.java
+++ b/src/main/java/seedu/address/model/event/EventPeriod.java
@@ -16,6 +16,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import seedu.address.model.event.exceptions.DateOutOfBoundsException;
+import seedu.address.model.event.exceptions.InvalidEventPeriodException;
 
 /**
  * Represents a period in time when an event will occur.
@@ -27,6 +28,7 @@ public class EventPeriod implements Comparable<EventPeriod> {
             + "    -'MM' is the month.\n"
             + "    -'dd' is the day.\n"
             + "    -'HH:mm' is the time in 24-hour format.";
+    public static final String PERIOD_INVALID = "The start date has to be before the end date.";
     public static final DateTimeFormatter DATE_TIME_STRING_FORMATTER = DateTimeFormatter.ofPattern(
             "yyyy-MM-dd HH:mm");
     private static final LocalTime MAX_TIME_OF_DAY = LocalTime.MIDNIGHT.minusMinutes(1);
@@ -85,13 +87,13 @@ public class EventPeriod implements Comparable<EventPeriod> {
 
         LocalDateTime startDateTime;
         LocalDateTime endDateTime;
-        try {
-            startDateTime = LocalDateTime.parse(startString, DATE_TIME_STRING_FORMATTER);
-            endDateTime = LocalDateTime.parse(endString, DATE_TIME_STRING_FORMATTER);
-        } catch (DateTimeParseException invalidFormatException) {
-            return false;
+        startDateTime = LocalDateTime.parse(startString, DATE_TIME_STRING_FORMATTER);
+        endDateTime = LocalDateTime.parse(endString, DATE_TIME_STRING_FORMATTER);
+
+        if (!startDateTime.isBefore(endDateTime)) {
+            throw new InvalidEventPeriodException();
         }
-        return startDateTime.isBefore(endDateTime);
+        return true;
     }
 
     /**

--- a/src/main/java/seedu/address/model/event/exceptions/InvalidEventPeriodException.java
+++ b/src/main/java/seedu/address/model/event/exceptions/InvalidEventPeriodException.java
@@ -1,0 +1,7 @@
+package seedu.address.model.event.exceptions;
+
+/**
+ * This exception is thrown when an event period is invalid.
+ */
+public class InvalidEventPeriodException extends RuntimeException {
+}

--- a/src/main/java/seedu/address/model/event/exceptions/InvalidEventPeriodException.java
+++ b/src/main/java/seedu/address/model/event/exceptions/InvalidEventPeriodException.java
@@ -1,7 +1,14 @@
 package seedu.address.model.event.exceptions;
 
+
 /**
  * This exception is thrown when an event period is invalid.
  */
 public class InvalidEventPeriodException extends RuntimeException {
+    /**
+     * @param message should contain relevant information on the failed constraint(s)
+     */
+    public InvalidEventPeriodException(String message) {
+        super(message);
+    }
 }

--- a/src/main/java/seedu/address/model/task/Deadline.java
+++ b/src/main/java/seedu/address/model/task/Deadline.java
@@ -8,7 +8,7 @@ import java.time.format.DateTimeParseException;
 import java.util.Optional;
 
 import seedu.address.commons.util.ToStringBuilder;
-import seedu.address.model.event.exceptions.InvalidDeadlineException;
+import seedu.address.model.task.exceptions.InvalidDeadlineException;
 
 /**
  * An object representing the deadline of a task.

--- a/src/main/java/seedu/address/model/task/TaskDescription.java
+++ b/src/main/java/seedu/address/model/task/TaskDescription.java
@@ -58,6 +58,6 @@ public class TaskDescription implements Comparable<TaskDescription> {
 
     @Override
     public int compareTo(TaskDescription other) {
-        return description.compareTo(other.description);
+        return description.toLowerCase().compareTo(other.description.toLowerCase());
     }
 }

--- a/src/main/java/seedu/address/model/task/exceptions/InvalidDeadlineException.java
+++ b/src/main/java/seedu/address/model/task/exceptions/InvalidDeadlineException.java
@@ -1,4 +1,4 @@
-package seedu.address.model.event.exceptions;
+package seedu.address.model.task.exceptions;
 
 /**
  * An exception thrown when a string of improper format is used to create a Deadline.

--- a/src/test/java/seedu/address/model/event/EventPeriodTest.java
+++ b/src/test/java/seedu/address/model/event/EventPeriodTest.java
@@ -57,20 +57,20 @@ public class EventPeriodTest {
     public void isValidPeriodTest() {
         assertTrue(isValidPeriod(VALID_START_DATE_EARLIER, VALID_END_DATE_EARLIER));
 
-        assertThrows(InvalidEventPeriodException.class,
-                () -> isValidPeriod(VALID_END_DATE_EARLIER, VALID_START_DATE_EARLIER));
+        assertThrows(InvalidEventPeriodException.class, () ->
+                isValidPeriod(VALID_END_DATE_EARLIER, VALID_START_DATE_EARLIER));
 
-        assertThrows(InvalidEventPeriodException.class,
-                () -> isValidPeriod(VALID_START_DATE_EARLIER, VALID_START_DATE_EARLIER));
+        assertThrows(InvalidEventPeriodException.class, () ->
+                isValidPeriod(VALID_START_DATE_EARLIER, VALID_START_DATE_EARLIER));
 
-        assertThrows(DateTimeParseException.class,
-                () -> isValidPeriod(INVALID_DATE, VALID_END_DATE_EARLIER));
+        assertThrows(DateTimeParseException.class, () ->
+                isValidPeriod(INVALID_DATE, VALID_END_DATE_EARLIER));
 
-        assertThrows(DateTimeParseException.class,
-                () -> isValidPeriod(VALID_START_DATE_EARLIER, INVALID_DATE));
+        assertThrows(DateTimeParseException.class, () ->
+                isValidPeriod(VALID_START_DATE_EARLIER, INVALID_DATE));
 
-        assertThrows(DateTimeParseException.class,
-                () -> isValidPeriod(INVALID_DATE, INVALID_DATE));
+        assertThrows(DateTimeParseException.class, () ->
+                isValidPeriod(INVALID_DATE, INVALID_DATE));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/event/EventPeriodTest.java
+++ b/src/test/java/seedu/address/model/event/EventPeriodTest.java
@@ -8,16 +8,21 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_END_DATE_EARLIE
 import static seedu.address.logic.commands.CommandTestUtil.VALID_END_DATE_LATER;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_START_DATE_EARLIER;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_START_DATE_LATER;
+import static seedu.address.model.event.EventPeriod.DATE_TIME_STRING_FORMATTER;
+import static seedu.address.model.event.EventPeriod.MAX_TIME_OF_DAY;
 import static seedu.address.model.event.EventPeriod.isValidPeriod;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import java.time.Duration;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.model.event.exceptions.DateOutOfBoundsException;
 import seedu.address.model.event.exceptions.InvalidEventPeriodException;
 import seedu.address.testutil.EventPeriodBuilder;
 
@@ -116,6 +121,29 @@ public class EventPeriodTest {
         EventPeriod validEventPeriod = new EventPeriodBuilder().build();
 
         assertFalse(validEventPeriod.getDates().isEmpty());
+    }
+
+    @Test
+    public void boundByDateTest() {
+        LocalDate input = LocalDate.of(2023, 1, 2);
+
+        EventPeriod startAndEnd = new EventPeriodBuilder().build();
+        EventPeriod startNotEnd = new EventPeriodBuilder().changeEnd("2023-01-03 15:00").build();
+        EventPeriod expectedStartNotEnd = new EventPeriodBuilder()
+                .changeEnd(input.atTime(MAX_TIME_OF_DAY).format(DATE_TIME_STRING_FORMATTER)).build();
+        EventPeriod endNotStart = new EventPeriodBuilder().changeStart("2023-01-01 15:00").build();
+        EventPeriod expectedEndNotStart = new EventPeriodBuilder()
+                .changeStart(input.atTime(LocalTime.MIDNIGHT).format(DATE_TIME_STRING_FORMATTER)).build();
+        EventPeriod outOfBounds = new EventPeriodBuilder()
+                .changeStartAndEnd("2022-01-03 15:00", "2022-01-04 15:00").build();
+
+        assertEquals(startAndEnd, startAndEnd.boundPeriodByDate(input));
+
+        assertEquals(expectedStartNotEnd, startNotEnd.boundPeriodByDate(input));
+
+        assertEquals(expectedEndNotStart, endNotStart.boundPeriodByDate(input));
+
+        assertThrows(DateOutOfBoundsException.class, () -> outOfBounds.boundPeriodByDate(input));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/event/EventPeriodTest.java
+++ b/src/test/java/seedu/address/model/event/EventPeriodTest.java
@@ -18,6 +18,7 @@ import java.time.format.DateTimeParseException;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.model.event.exceptions.InvalidEventPeriodException;
 import seedu.address.testutil.EventPeriodBuilder;
 
 public class EventPeriodTest {
@@ -56,15 +57,20 @@ public class EventPeriodTest {
     public void isValidPeriodTest() {
         assertTrue(isValidPeriod(VALID_START_DATE_EARLIER, VALID_END_DATE_EARLIER));
 
-        assertFalse(isValidPeriod(VALID_END_DATE_EARLIER, VALID_START_DATE_EARLIER));
+        assertThrows(InvalidEventPeriodException.class,
+                () -> isValidPeriod(VALID_END_DATE_EARLIER, VALID_START_DATE_EARLIER));
 
-        assertFalse(isValidPeriod(VALID_START_DATE_EARLIER, VALID_START_DATE_EARLIER));
+        assertThrows(InvalidEventPeriodException.class,
+                () -> isValidPeriod(VALID_START_DATE_EARLIER, VALID_START_DATE_EARLIER));
 
-        assertFalse(isValidPeriod(INVALID_DATE, VALID_END_DATE_EARLIER));
+        assertThrows(DateTimeParseException.class,
+                () -> isValidPeriod(INVALID_DATE, VALID_END_DATE_EARLIER));
 
-        assertFalse(isValidPeriod(VALID_START_DATE_EARLIER, INVALID_DATE));
+        assertThrows(DateTimeParseException.class,
+                () -> isValidPeriod(VALID_START_DATE_EARLIER, INVALID_DATE));
 
-        assertFalse(isValidPeriod(INVALID_DATE, INVALID_DATE));
+        assertThrows(DateTimeParseException.class,
+                () -> isValidPeriod(INVALID_DATE, INVALID_DATE));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/task/DeadlineTest.java
+++ b/src/test/java/seedu/address/model/task/DeadlineTest.java
@@ -13,7 +13,7 @@ import java.time.format.DateTimeFormatter;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.model.event.exceptions.InvalidDeadlineException;
+import seedu.address.model.task.exceptions.InvalidDeadlineException;
 
 class DeadlineTest {
     private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");

--- a/src/test/java/seedu/address/storage/JsonAdaptedEventTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedEventTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.event.EventDescription;
 import seedu.address.model.event.EventPeriod;
+import seedu.address.model.event.exceptions.InvalidEventPeriodException;
 
 public class JsonAdaptedEventTest {
     private static final String INVALID_DESCRIPTION = "";
@@ -58,8 +59,8 @@ public class JsonAdaptedEventTest {
     @Test
     public void toModelType_isInvalidEventPeriod_throwsIllegalValueException() {
         JsonAdaptedEvent event = new JsonAdaptedEvent(VALID_DESCRIPTION, INVALID_EVENT_PERIOD);
-        String expectedMessage = EventPeriod.MESSAGE_CONSTRAINTS;
-        assertThrows(IllegalValueException.class, expectedMessage, event::toModelType);
+        String expectedMessage = EventPeriod.PERIOD_INVALID;
+        assertThrows(InvalidEventPeriodException.class, expectedMessage, event::toModelType);
     }
 
 }


### PR DESCRIPTION
Fixed Issues
#111 and #139 
Added a new exception "InvalidEventPeriodException" that is thrown by isValidEventPeriod when the event period is invalid due to the end time being before the start time. 
Changed the implementation of the addEventParser to catch different exceptions and throw different error messages for invalid event periods and invalid inputs for event periods.
#117 
Clarified UG documentation on how this command works to reduce confusion.

Edit: Fixed several other bugs
#107 
Clarified in the UG that using a field prefix but leaving the field blank in the input will cause the contacts to still be filtered by an empty field, causing all contacts to be displayed.
#115 
Fixed in UG
#118 
Clarified in the UG that although there is no character limit for the description, the display will be truncated if the description is too long.
#119 
Fixed the comparator to ignore letter case when comparing.
#125 
Clarified in the UG that filter feature should not be case sensitive.
#129 
Clarified in the UG that adding a task with a deadline date that is invalid but with a day number of 31 or less still adds the task on the last day of the indicated month.